### PR TITLE
Account authority delete issue

### DIFF
--- a/src/components/cards/Account/AccountKeyRow.tsx
+++ b/src/components/cards/Account/AccountKeyRow.tsx
@@ -1,9 +1,15 @@
 import { FC, useEffect, useState } from 'react';
 import { Button, Col, Form, InputGroup, Row } from 'react-bootstrap';
-import { IAccountKeyRowProps } from '../../../interfaces/cardInterfaces';
-import { useAppDispatch } from '../../../redux/app/hooks';
+import { Authorities } from '../../../interfaces/account.interface';
+import {
+  IAccountKeyRowProps,
+  IDeleteAccount,
+  IDeleteKey,
+} from '../../../interfaces/cardInterfaces';
+import { useAppDispatch, useAppSelector } from '../../../redux/app/hooks';
 import {
   deleteAccount,
+  deleteKey,
   updateAccount,
 } from '../../../redux/features/updateAuthorities/updateAuthoritiesSlice';
 import { useDidMountEffect } from '../../../utils/utils';
@@ -21,7 +27,9 @@ export const AccountKeyRow: FC<IAccountKeyRowProps> = ({
   const [weight, setWeight] = useState<number>(accountKeyAuth[1]);
   const [newAuth, setNewAuth] = useState<[string, number]>(accountKeyAuth);
   const dispatch = useAppDispatch();
-
+  const newAuthorities: Authorities = useAppSelector(
+    (state) => state.updateAuthorities.NewAuthorities,
+  );
   useEffect(() => {
     switch (color) {
       case 'red':
@@ -58,13 +66,25 @@ export const AccountKeyRow: FC<IAccountKeyRowProps> = ({
 
   useDidMountEffect(() => {
     if (deleteComponentKey !== '') {
-      const payload: IAccountKeyRowProps = {
-        authorityName,
-        type,
-        accountKeyAuth: [...newAuth],
-      };
-      console.log('deleteDispatchPayload: ', payload);
-      dispatch(deleteAccount(payload));
+      switch (type.toLowerCase()) {
+        case 'accounts':
+          const accountToDelete: IDeleteAccount = {
+            type: authorityName,
+            username: newAuth[0],
+            authorities: newAuthorities,
+          };
+          dispatch(deleteAccount(accountToDelete));
+          break;
+        case 'keys':
+          const keyToDelete: IDeleteKey = {
+            type: authorityName,
+            key: newAuth[0],
+            authorities: newAuthorities,
+          };
+          dispatch(deleteKey(keyToDelete));
+          break;
+      }
+
       setDeleteComponentKey('');
     }
   }, [deleteComponentKey]);

--- a/src/interfaces/cardInterfaces.ts
+++ b/src/interfaces/cardInterfaces.ts
@@ -1,26 +1,39 @@
 import * as Hive from '@hiveio/dhive';
+import { Authorities } from './account.interface';
 
 export interface IAddAccountKeyProps {
-    authAccountType: string;
-    setNewAccount: Function;
-  }
-  
+  authAccountType: string;
+  setNewAccount: Function;
+}
+
 export interface IAccountKeysCardProps {
-authorityName: string;
-authAccountType: string;
-accountKeyAuths: [string, number][];
+  authorityName: string;
+  authAccountType: string;
+  accountKeyAuths: [string, number][];
 }
 
 export interface IAccountKeyRowProps {
-authorityName: string;
-type: string;
-accountKeyAuth?: [string, number];
-threshold?: number;
-isLoggedIn?:boolean;
-componentColor?:string;
+  authorityName: string;
+  type: string;
+  accountKeyAuth?: [string, number];
+  threshold?: number;
+  isLoggedIn?: boolean;
+  componentColor?: string;
 }
 
 export interface IAuthorityCardProps {
-authorityName: string;
-authority: Hive.AuthorityType;
+  authorityName: string;
+  authority: Hive.AuthorityType;
+}
+
+export interface IDeleteAccount {
+  username: string;
+  type: string;
+  authorities: Authorities;
+}
+
+export interface IDeleteKey {
+  key: string;
+  type: string;
+  authorities: Authorities;
 }

--- a/src/utils/account-utils.ts
+++ b/src/utils/account-utils.ts
@@ -86,3 +86,67 @@ export const UpdateAuthorityWeightThresh = (
   }
   return newAuthorities;
 };
+
+export const removeAccount = (
+  type: string,
+  username: string,
+  newAccount: Authorities,
+) => {
+  const accountCopy = structuredClone(newAccount);
+
+  switch (type.toLocaleLowerCase()) {
+    case 'owner':
+      accountCopy.owner.account_auths = accountCopy.owner.account_auths.filter(
+        (account) => {
+          return account[0] !== username;
+        },
+      );
+      break;
+    case 'active':
+      accountCopy.active.account_auths =
+        accountCopy.active.account_auths.filter((account) => {
+          return account[0] !== username;
+        });
+      break;
+    case 'posting':
+      accountCopy.posting.account_auths =
+        accountCopy.posting.account_auths.filter((account) => {
+          return account[0] !== username;
+        });
+      break;
+  }
+
+  return accountCopy;
+};
+
+export const removeKey = (
+  type: string,
+  key: string,
+  newAccount: Authorities,
+) => {
+  const accountCopy = structuredClone(newAccount);
+  switch (type.toLocaleLowerCase()) {
+    case 'owner':
+      accountCopy.owner.key_auths = accountCopy.owner.key_auths.filter(
+        (accountKey) => {
+          return accountKey[0] !== key;
+        },
+      );
+      break;
+
+    case 'active':
+      accountCopy.active.key_auths = accountCopy.active.key_auths.filter(
+        (accountKey) => {
+          return accountKey[0] !== key;
+        },
+      );
+      break;
+    case 'posting':
+      accountCopy.posting.key_auths = accountCopy.posting.key_auths.filter(
+        (accountKey) => {
+          return accountKey[0] != key;
+        },
+      );
+  }
+  return accountCopy;
+};


### PR DESCRIPTION
The bug: 

- When you have an authority that is both listed in your owner/active/posting, deleting one from it will delete all.  

Ex.  
1) accountB is in active and posting authorities of accountA
2) When accountA delete accountB in active authorities, it will also be deleted in posting. 

Main issue: object mutation in redux