### PR TITLE
dont allow 0 weight and thresh

### DIFF
--- a/src/components/cards/Account/AccountKeyRow.tsx
+++ b/src/components/cards/Account/AccountKeyRow.tsx
@@ -177,8 +177,8 @@ export const AccountKeyRow: FC<IAccountKeyRowProps> = ({
         break;
     }
   };
-  const handleUpdate = (v: number) => {
-    setWeight(v);
+  const handleUpdateWeight = (weight: number) => {
+    if (weight > 0) setWeight(weight);
   };
   const handleDelete = () => {
     setDeleteComponentKey(accountKeyAuth[0]);
@@ -220,7 +220,7 @@ export const AccountKeyRow: FC<IAccountKeyRowProps> = ({
                 step="1"
                 className={`form-control ${outlineColor}`}
                 id="weightInput"
-                onChange={(e) => handleUpdate(parseInt(e.target.value))}
+                onChange={(e) => handleUpdateWeight(parseInt(e.target.value))}
                 placeholder={weight.toString()}
                 value={weight}
                 readOnly={readOnly}

--- a/src/components/cards/Account/AddAccountKeyRow.tsx
+++ b/src/components/cards/Account/AddAccountKeyRow.tsx
@@ -44,9 +44,14 @@ export function AddAccountKeyRow({
     if (accountName !== '') {
       setNewAccount([accountName, weight]);
       setAccountName('');
-      setAccountWeight(1);
+      handleSetWeight(1);
     }
   };
+
+  const handleSetWeight = (weight: number) => {
+    if (weight > 0) setAccountWeight(weight);
+  };
+
   const handleNewKeyOnClick = () => {
     const pvtKey: Hive.PrivateKey = AccountUtils.getPrivateKeyFromSeed(
       user.data.username + Date.now() + Math.random(),
@@ -114,7 +119,7 @@ export function AddAccountKeyRow({
                   id="weightInput"
                   placeholder={'1'}
                   onChange={(e) => {
-                    setAccountWeight(parseInt(e.target.value));
+                    handleSetWeight(parseInt(e.target.value));
                   }}
                   value={weight}
                 />

--- a/src/components/cards/Account/AuthorityWeightThresholdRow.tsx
+++ b/src/components/cards/Account/AuthorityWeightThresholdRow.tsx
@@ -22,7 +22,6 @@ export function AuthorityWeightThreshold({
   const thresholdWarningRedux = useAppSelector(
     (state) => state.updateAuthorities.thresholdWarning,
   );
-  
 
   useEffect(() => {
     setReadOnly(!enableEdit);
@@ -35,9 +34,14 @@ export function AuthorityWeightThreshold({
   }, [isLoggedIn]);
 
   useEffect(() => {
-    setNewWeightThresh(threshold);
+    handleThresholdOnChange(threshold);
   }, [threshold]);
 
+  const handleThresholdOnChange = (thresh: number) => {
+    if (thresh > 0) {
+      setNewWeightThresh(thresh);
+    }
+  };
   useDidMountEffect(() => {
     if (weight !== threshold) {
       setEdiFlag('text-danger');
@@ -65,7 +69,7 @@ export function AuthorityWeightThreshold({
           className="form-control"
           id="threshInput"
           onChange={(e) => {
-            setNewWeightThresh(parseInt(e.target.value));
+            handleThresholdOnChange(parseInt(e.target.value));
           }}
           placeholder={weight.toString()}
           value={weight}


### PR DESCRIPTION
Bug:

1. Zero weight or threshold can be set when typed
2. Zero weight can be set when adding new key

**Solution** Restricted zero weight on the following:

- Account authority
- Key authority
- Threshold